### PR TITLE
Cosmetics

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Simon Christ (SimonChrist@gmx.de)
 Luca Ferranti (ferranti-luca@virgilio.it)
-Trevor Keller (trevor.keller@nist.gov>
+Trevor Keller (trevor.keller@nist.gov)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Simon Christ (SimonChrist@gmx.de)
 Luca Ferranti (ferranti-luca@virgilio.it)
+Trevor Keller (trevor.keller@nist.gov>

--- a/_episodes/02-REPL.md
+++ b/_episodes/02-REPL.md
@@ -18,13 +18,49 @@ keypoints:
 
 # Entering the REPL
 
+Melissa and her classmates open a terminal and launch `julia`:
+
+~~~
+julia
+~~~
+{: .language-bash}
+~~~
+               _
+   _       _ _(_)_     |  Documentation: https://docs.julialang.org
+  (_)     | (_) (_)    |
+   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
+  | | | | | | |/ _` |  |
+  | | |_| | | | (_| |  |  Version 1.7.0 (2021-11-30)
+ _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+|__/                   |
+
+julia>
+~~~
+{: .output}
+
+This is the so-called REPL, which stands for
+**r**ead-**e**valuate-**p**rint-**l**oop. The interactive command-line REPL
+allows quick and easy execution of Julia statements.
+
+Like the terminal, the Julia REPL has a prompt, where it awaits input:
+
+~~~
+julia>
+~~~
+{: .language-julia}
+
+> ## Implicit prompt
+>
+> Most of the code boxes that follow *do not show the `julia>` prompt*, even
+> though it's there in the REPL. Why?
+>
+> It's important to delineate input (what you type) and output (how the
+> machine responds). The prompt can be confusing, so it is excluded. You may
+> assume that any **Julia** box prepends the prompt on each line of input.
+{: .callout}
+
 ## Variables
 
-After downloading and executing a Julia binary from
-[julialang.org](https://julialang.org), Melissa and her classmates face the so
-called REPL, which stands for **r**ead-**e**valuate-**p**rint-**l**oop. The
-interactive command-line REPL allows quick and easy execution of Julia
-statements.
 The first thing they try is to perform basic arithmetic operations:
 
 ~~~
@@ -56,7 +92,10 @@ She can also check which variables are defined in the current session by
 running
 
 ~~~
-julia> varinfo()
+varinfo()
+~~~
+{: .language-julia}
+~~~
   name                    size summary
   –––––––––––––––– ––––––––––– –––––––
   Base                         Module
@@ -67,40 +106,94 @@ julia> varinfo()
   distance             8 bytes Float64
   distance_x_2         8 bytes Float64
 ~~~
-{: .language-julia}
+{: .output}
 
 ## Unicode
 
 In Julia, Unicode characters are also allowed as variables like `α = 2`.
-Unicode characters can be entered by a backslash followed by their LaTeX-name
-and then pressing `tab` (in this case `\alpha``tab`).
+Unicode characters can be entered by a backslash followed by their [LaTeX
+name][latex] and then pressing <kbd>tab</kbd> (in this case
+`\alpha`<kbd>tab</kbd>).
 
 ## REPL-modes
 
 Unfortunately Melissa can't remember the LaTeX name of ∂ so she copies the
-character, presses `?` to enter the help mode, pastes the character and gets
+character, presses <kbd>?</kbd> for help mode, pastes the ∂ character, then
+presses enter:
 
 ~~~
+?
 help?> ∂
+~~~
+{: .language-julia}
+~~~
 "∂" can be typed by \partial<tab>
 ~~~
 {: .output}
 
 Great! This way she can easily look up the names she needs.
-She gets back to normal mode by pressing backspace.
+She gets back to normal mode by pressing <kbd>backspace</kbd>.
 
-Another useful mode is the shell mode that can be entered by pressing `;`.
-The prompt has now changed to shell.
-It can be used to issue commands of the underlying shell, but don't confuse it
-with an actual shell: Special shell syntax like piping won't work.
+Another useful mode is the ***shell mode*** that can be entered by pressing
+<kbd>;</kbd>. The prompt has now changed:
 
-> ## Hello shell mode
+~~~
+;
+~~~
+{: .language-julia}
+~~~
+shell>
+~~~
+{: .output}
+
+Shell mode can be used to issue commands to the underlying shell, but don't
+confuse it with an actual shell: special shell syntax like piping won't work.
+Like before, hit <kbd>backspace</kbd> to get back to the Julia prompt.
+
+> ## Hello, **`shell>`**!
 >
 > Use the shell mode to start nano and save your first `.jl` file
+>
+> > ## Solution
+> >
+> > ~~~
+> > ;
+> > ~~~
+> > {: .language-julia}
+> > ~~~
+> > shell> nano hello.jl
+> > shell> cat hello.jl
+> > ~~~
+> > {: .language-bash}
+> > ~~~
+> > print("Hello World")
+> > ~~~
+> > {: .output}
+> > ~~~
+> > shell> julia hello.jl
+> > ~~~
+> > {: .language-bash}
+> > ~~~
+> > Hello World
+> > ~~~
+> > {: .output}
+> > <kbd>backspace</kbd>
 {: .challenge}
 
-Finally there is the package mode that is entered with `]` which is used for
-package management, which will be covered later on.
-To exit the shell or pkg mode use `backspace`.
+Finally there is ***package mode*** that is entered with <kbd>]</kbd> which is
+used for package management, which will be covered later on:
+
+~~~
+]
+~~~
+{: .language-julia}
+~~~
+pkg>
+~~~
+{: .output}
+
+To exit ***shell*** or ***pkg*** mode, hit <kbd>backspace</kbd>.
+
+[latex]: http://oeis.org/wiki/List_of_LaTeX_mathematical_symbols
 
 {% include links.md %}

--- a/_episodes/02-REPL.md
+++ b/_episodes/02-REPL.md
@@ -10,9 +10,9 @@ objectives:
 - "Learn about REPL modes."
 keypoints:
 - "The REPL reads the given input, evaluates the given expression and prints the resulting output to the user."
-- "Pressing `?` enters help mode."
-- "Pressing `;` enters shell mode."
-- "Pressing `]` enters pkg mode."
+- "Pressing <kbd>?</kbd> enters help mode."
+- "Pressing <kbd>;</kbd> enters shell mode."
+- "Pressing <kbd>]</kbd> enters pkg mode."
 
 ---
 

--- a/_episodes/02-REPL.md
+++ b/_episodes/02-REPL.md
@@ -13,7 +13,6 @@ keypoints:
 - "Pressing <kbd>?</kbd> enters help mode."
 - "Pressing <kbd>;</kbd> enters shell mode."
 - "Pressing <kbd>]</kbd> enters pkg mode."
-
 ---
 
 # Entering the REPL
@@ -118,11 +117,16 @@ name][latex] and then pressing <kbd>tab</kbd> (in this case
 ## REPL-modes
 
 Unfortunately Melissa can't remember the LaTeX name of ∂ so she copies the
-character, presses <kbd>?</kbd> for help mode, pastes the ∂ character, then
-presses enter:
+character, presses <kbd>?</kbd> for help mode,
 
 ~~~
 ?
+~~~
+{: .language-julia}
+
+pastes the ∂ character, then presses enter:
+
+~~~
 help?> ∂
 ~~~
 {: .language-julia}
@@ -144,7 +148,7 @@ Another useful mode is the ***shell mode*** that can be entered by pressing
 ~~~
 shell>
 ~~~
-{: .output}
+{: .language-julia}
 
 Shell mode can be used to issue commands to the underlying shell, but don't
 confuse it with an actual shell: special shell syntax like piping won't work.
@@ -164,7 +168,7 @@ Like before, hit <kbd>backspace</kbd> to get back to the Julia prompt.
 > > shell> nano hello.jl
 > > shell> cat hello.jl
 > > ~~~
-> > {: .language-bash}
+> > {: .language-julia}
 > > ~~~
 > > print("Hello World")
 > > ~~~
@@ -172,7 +176,7 @@ Like before, hit <kbd>backspace</kbd> to get back to the Julia prompt.
 > > ~~~
 > > shell> julia hello.jl
 > > ~~~
-> > {: .language-bash}
+> > {: .language-julia}
 > > ~~~
 > > Hello World
 > > ~~~
@@ -190,7 +194,7 @@ used for package management, which will be covered later on:
 ~~~
 pkg>
 ~~~
-{: .output}
+{: .language-julia}
 
 To exit ***shell*** or ***pkg*** mode, hit <kbd>backspace</kbd>.
 

--- a/_episodes/02-REPL.md
+++ b/_episodes/02-REPL.md
@@ -182,6 +182,7 @@ Like before, hit <kbd>backspace</kbd> to get back to the Julia prompt.
 > > ~~~
 > > {: .output}
 > > <kbd>backspace</kbd>
+> {: .solution}
 {: .challenge}
 
 Finally there is ***package mode*** that is entered with <kbd>]</kbd> which is

--- a/_episodes/03-types.md
+++ b/_episodes/03-types.md
@@ -89,14 +89,14 @@ are between `Float64` and `Any`:
    {: .output}
 
 So we have the relationship `Float64 <: AbstractFloat <: Real <: Number <: Any`
-where __`<:`__ is the ***subtype operator***, used here to mean the item
+where [__`<:`__ is the ***subtype operator***][subtype], used here to mean the item
 on the left "is a subtype of" the item on the right.
 
 `Float64` is a _concrete_ type, which means that you can actually create
 objects of this type.
 For example `1.0` is an object of type `Float64`.
 We can check this at the REPL using either (or both) the
-`typeof` function or the `isa` operator:
+`typeof` function or the [`isa` operator][isa]:
 
 ~~~
 typeof(1.0)
@@ -195,5 +195,7 @@ a good idea to make it a subtype of `AbstractVector`.
 ***Melissa decides to keep going and come back to this later.***
 
 [hierarchy]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Type-hierarchy-for-julia-numbers.png/1200px-Type-hierarchy-for-julia-numbers.png
+[isa]: https://docs.julialang.org/en/v1/base/base/#Core.isa
+[subtype]: https://docs.julialang.org/en/v1/base/base/#Core.:%3C:
 
 {% include links.md %}

--- a/_episodes/03-types.md
+++ b/_episodes/03-types.md
@@ -47,8 +47,8 @@ end
 ### Types and hierarchy
 
 Here `::Float64` is a type specification, indicating that this variable should
-be a 64-bit floating point number, and ***`::` is an operator*** that
-is read as "is an instance of."
+be a 64-bit floating point number, and __`::`__ is an ***operator*** that
+is read "is an instance of."
 If Melissa hadn't specified the type, the variables would have the type `Any`
 by default.
 
@@ -88,14 +88,8 @@ are between `Float64` and `Any`:
    ~~~
    {: .output}
 
-So we have the relationship
-
-~~~
-Float64 <: AbstractFloat <: Real <: Number <: Any
-~~~
-{: .language-julia}
-
-where ***`<:` is the subtype operator***, used here to mean the item
+So we have the relationship `Float64 <: AbstractFloat <: Real <: Number <: Any`
+where __`<:`__ is the ***subtype operator***, used here to mean the item
 on the left "is a subtype of" the item on the right.
 
 `Float64` is a _concrete_ type, which means that you can actually create
@@ -165,11 +159,11 @@ Have a look at this visualization of all subtypes of `Number`:
 ## Creating a subtype
 
 A concrete type can be made a subtype of an abstract type with the
-***subtype operator `<:`***.
+subtype operator __`<:`__.
 Since `Trebuchet` contains several fields that are mutable Melissa thinks it is
 a good idea to make it a subtype of `AbstractVector`.
 
-> ## Caveat: redefining `struct`s
+> ## Caveat: Redefining Structs
 >
 > ~~~
 > mutable struct Trebuchet <: AbstractVector{Float64}
@@ -187,11 +181,14 @@ a good idea to make it a subtype of `AbstractVector`.
 > ~~~
 > {: .error}
 >
+> This error message is clear: you're not allowed to define a `struct`
+> using a name that's already in use.
+>
 > > ## Restart the REPL
 > >
 > > In Julia it is not very easy to redefine `struct`s.
 > > It is necessary to restart the REPL to define the new definition of
-> > `Trebuchet` or take a different name.
+> > `Trebuchet`, or take a different name instead.
 > {: .discussion}
 {: .callout}
 

--- a/_episodes/03-types.md
+++ b/_episodes/03-types.md
@@ -47,38 +47,73 @@ end
 ### Types and hierarchy
 
 Here `::Float64` is a type specification, indicating that this variable should
-be a 64-bit floating point number.
+be a 64-bit floating point number, and ***`::` is an operator*** that
+is read as "is an instance of."
 If Melissa hadn't specified the type, the variables would have the type `Any`
 by default.
 
-In Julia every type can have only one supertype, so lets check how many types
-are between `Float64` and `Any`
+In Julia every type can have only one supertype, so let's count how many types
+are between `Float64` and `Any`:
+
+1. ~~~
+   supertype(Float64)
+   ~~~
+   {: .language-julia}
+   ~~~
+   AbstractFloat
+   ~~~
+   {: .output}
+2. ~~~
+   supertype(AbstractFloat)
+   ~~~
+   {: .language-julia}
+   ~~~
+   Real
+   ~~~
+   {: .output}
+3. ~~~
+   supertype(Real)
+   ~~~
+   {: .language-julia}
+   ~~~
+   Number
+   ~~~
+   {: .output}
+4. ~~~
+   supertype(Number)
+   ~~~
+   {: .language-julia}
+   ~~~
+   Any
+   ~~~
+   {: .output}
+
+So we have the relationship
 
 ~~~
-julia> supertype(Float64)
-AbstractFloat
-julia> supertype(AbstractFloat)
-Real
-julia> supertype(Real)
-Number
-julia> supertype(Number)
-Any
+Float64 <: AbstractFloat <: Real <: Number <: Any
 ~~~
 {: .language-julia}
 
-So we have the relationship `Float64 <: AbstractFloat <: Real <: Number <:
-Any`, where `<:` means "subtype of".
+where ***`<:` is the subtype operator***, used here to mean the item
+on the left "is a subtype of" the item on the right.
 
 `Float64` is a _concrete_ type, which means that you can actually create
 objects of this type.
-For example `1.0` is a object of type `Float64`.
-We can check this at the REPL:
+For example `1.0` is an object of type `Float64`.
+We can check this at the REPL using either (or both) the
+`typeof` function or the `isa` operator:
 
 ~~~
-julia> 1.0 isa Float64
-true
+typeof(1.0)
+1.0 isa Float64
 ~~~
 {: .language-julia}
+~~~
+Float64
+true
+~~~
+{: .output}
 
 All the other types are _abstract_ types that are used to address groups of
 types.
@@ -88,23 +123,32 @@ value that is a subtype of `Real`.
 Let's quickly check what are all the subtypes of `Real`:
 
 ~~~
-julia> subtypes(Real)
+subtypes(Real)
+~~~
+{: .language-julia}
+~~~
 4-element Array{Any,1}:
  AbstractFloat
  AbstractIrrational
  Integer
  Rational
 ~~~
-{: .language-julia}
+{: .output}
 
 This way the types form a tree with abstract types on the nodes and concrete
 types as leaves.
 Have a look at this visualization of all subtypes of `Number`:
-![Type_tree-Number](https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Type-hierarchy-for-julia-numbers.png/1200px-Type-hierarchy-for-julia-numbers.png)
+![Type_tree-Number][hierarchy]
 
-> ## Is it `Real`?
+> ## Is it **Real**?
 >
-> For which of these types `T` is it false that `(1.0 isa T)`?
+> For which of the following types `T` would the following return
+> `false`?
+>
+> ~~~
+> 1.0 isa T
+> ~~~
+> {: .language-julia}
 >
 > 1. Real
 > 2. Number
@@ -114,41 +158,45 @@ Have a look at this visualization of all subtypes of `Number`:
 > > ## Solution
 > >
 > > The correct answer is 4:
-> > while `1` is an integer, `1.0` is its floating-point representation.
+> > while `1` is an integer, `1.0` is a floating-point value.
 > {: .solution}
 {: .challenge}
 
-
 ## Creating a subtype
 
-A concrete type can be made a subtype of an abstract type with the subtype
-operator `<:`.
+A concrete type can be made a subtype of an abstract type with the
+***subtype operator `<:`***.
 Since `Trebuchet` contains several fields that are mutable Melissa thinks it is
 a good idea to make it a subtype of `AbstractVector`.
 
-~~~
-julia> mutable struct Trebuchet <: AbstractVector{Float64}
-  counterweight::Float64
-  release_angle::Float64
-end
-~~~
-{: .language-julia}
-
-~~~
-ERROR: invalid redefinition of constant Trebuchet
-Stacktrace:
- [1] top-level scope
-   @ REPL[9]:1
-~~~
-{: .error}
-
 > ## Caveat: redefining `struct`s
 >
-> In Julia it is not very easy to redefine `struct`s.
-> It is necessary to restart the REPL to define the new definition of
-> `Trebuchet` or take a different name.
+> ~~~
+> mutable struct Trebuchet <: AbstractVector{Float64}
+>   counterweight::Float64
+>   release_angle::Float64
+> end
+> ~~~
+> {: .language-julia}
+> 
+> ~~~
+> ERROR: invalid redefinition of constant Trebuchet
+> Stacktrace:
+>  [1] top-level scope
+>    @ REPL[9]:1
+> ~~~
+> {: .error}
+>
+> > ## Restart the REPL
+> >
+> > In Julia it is not very easy to redefine `struct`s.
+> > It is necessary to restart the REPL to define the new definition of
+> > `Trebuchet` or take a different name.
+> {: .discussion}
 {: .callout}
 
-Melissa decides to keep going and come back to this later.
+***Melissa decides to keep going and come back to this later.***
+
+[hierarchy]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Type-hierarchy-for-julia-numbers.png/1200px-Type-hierarchy-for-julia-numbers.png
 
 {% include links.md %}

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -110,10 +110,10 @@ environment.
 > "main" branch on the GitHub repository, provides a function _and
 > its documentation_ that Melissa needs to use later on.
 >
-> If you know a package is stable, go ahead and install the JuliaHub
-> version. Otherwise, it's good to check how different the archived
-> version is from the current state. Click through the link under
-> "Repository" on the JuliaHub package page.
+> If you know a package is stable, go ahead and install the default version
+> registered on JuliaHub. Otherwise, it's good to check how different that
+> version is from the current state of the software project. Click through the
+> link under "Repository" on the JuliaHub package page.
 {: .callout}
 
 ## Using and importing packages

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -25,18 +25,18 @@ The necessary equations are really complicated, but an investigation on
 these and published it as the Julia package [`Trebuchet.jl`][trebuchet].
 That saves some real work.
 
-Melissa enters the package mode by pressing <kbd>]</kbd>:
+Melissa enters package mode by pressing <kbd>]</kbd>:
 
 ~~~
 ]
 ~~~
 {: .language-julia}
 
-The `julia>` prompt becomes a blue `pkg>` prompt that reads the Julia version
+The `julia>` prompt becomes a blue `pkg>` prompt that shows the Julia version
 that Melissa is running.
 
 After consulting the [documentation](https://julialang.github.io/Pkg.jl/v1/)
-she knows that the prompt is showing the *currently activated environment* and
+she knows that the prompt is showing the _currently activated environment_ and
 that this is the global environment that is activated by default.
 
 However, she doesn't want to clutter the global environment when working on her
@@ -107,8 +107,8 @@ environment.
 > However, that "release" version of the code is missing some
 > important features and, more important for learning, it has very
 > little documentation. The "development" version, represented by the
-> "main" branch on the GitHub repository, provides a function *and
-> its documentation* that Melissa needs to use later on.
+> "main" branch on the GitHub repository, provides a function _and
+> its documentation_ that Melissa needs to use later on.
 >
 > If you know a package is stable, go ahead and install the JuliaHub
 > version. Otherwise, it's good to check how different the archived

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -11,7 +11,7 @@ objectives:
 - "Learn to resolve name conflicts"
 - "Learn to activate environments"
 keypoints:
-- "Find packages on juliahub"
+- "Find packages on JuliaHub"
 - "add packages using `pkg> add`"
 - "use many small environments rather than one big environment"
 ---
@@ -21,15 +21,22 @@ keypoints:
 Now it is time for Melissa and their mates to simulate the launch of the
 trebuchet.
 The necessary equations are really complicated, but an investigation on
-[juliahub](https://juliahub.com/) revealed that someone already implemented
-these and published it as the Julia package `Trebuchet.jl`.
-That spares some real work.
+[JuliaHub](https://juliahub.com/) revealed that someone already implemented
+these and published it as the Julia package [`Trebuchet.jl`][trebuchet].
+That saves some real work.
 
-Melissa enters the package mode by pressing `]`.
-The `julia>` prompt becomes a blue prompt that reads the Julia version that
-Melissa is running.
+Melissa enters the package mode by pressing <kbd>]</kbd>:
+
+~~~
+]
+~~~
+{: .language-julia}
+
+The `julia>` prompt becomes a blue `pkg>` prompt that reads the Julia version
+that Melissa is running.
+
 After consulting the [documentation](https://julialang.github.io/Pkg.jl/v1/)
-she knows that the prompt is showing the currently activated environment and
+she knows that the prompt is showing the *currently activated environment* and
 that this is the global environment that is activated by default.
 
 However, she doesn't want to clutter the global environment when working on her
@@ -80,6 +87,11 @@ environment.
 (trebuchet) pkg> status
 ~~~
 {: .language-julia}
+~~~
+      Status `projects/trebuchet/Project.toml`
+  [98b73d46] Trebuchet v0.2.1
+~~~
+{: .output}
 
 ## Using and importing packages
 
@@ -87,9 +99,11 @@ Now that Melissa added the package to her environment, she needs to load it.
 Julia provides two keywords for loading packages: `using` and `import`.
 
 The difference is that `import` brings only the name of the package into the
-namespace and then all functions in that package need the name in front.
-But packages can also define an export list for function names that should be
-brought into the user's namespace when he loads the package with `using`.
+namespace and then all functions in that package need the name in front
+(prefixed).
+But packages can define a list of function names to export, which means the
+functions should be brought into the user's namespace when he loads the package
+with `using`.
 This makes working at the REPL more convenient.
 
 ### Name conflicts
@@ -98,11 +112,14 @@ It may happen that name conflicts arise.
 For example Melissa defined a structure named `Trebuchet`, but the package she
 added to the environment is also named `Trebuchet`.
 Now she would get an error if she tried to `import`/`using` it directly.
-One solution is to rename the package upon `import` with `as`:
+One solution is to assign a nickname or alias to the package upon `import`
+using the keyword ***`as`***:
 
 ~~~
 import Trebuchet as Trebuchets
 ~~~
 {: .language-julia}
+
+[trebuchet]: https://juliahub.com/ui/Search?q=trebuchet&type=packages
 
 {% include links.md %}

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -47,10 +47,11 @@ project, so she creates a new environment via
 ~~~
 {: .language-julia}
 
-In this environment she adds the `Trebuchet` package by typing
+In this environment she adds the `Trebuchet` package from its
+open source code [repository on GitHub][ghtreb] by typing
 
 ~~~
-(trebuchet) pkg> add Trebuchet
+(trebuchet) pkg> add https://github.com/FluxML/Trebuchet.jl
 ~~~
 {: .language-julia}
 
@@ -89,9 +90,30 @@ environment.
 {: .language-julia}
 ~~~
       Status `projects/trebuchet/Project.toml`
-  [98b73d46] Trebuchet v0.2.1
+  [98b73d46] Trebuchet v0.2.1 `https://github.com/FluxML/Trebuchet.jl#master`
 ~~~
 {: .output}
+
+> ## Why use GitHub?
+>
+> Melissa could have added the JuliaHub version of Trebuchet.jl by
+> typing
+>
+> ~~~
+> (trebuchet) pkg> add Trebuchet
+> ~~~
+> {: .language-julia)
+>
+> However, that "release" version of the code is missing some
+> important features and, more important for learning, it has very
+> little documentation. The "development" version, represented by the
+> "main" branch on the GitHub repository, provides a function *and
+> its documentation* that Melissa needs to use later on.
+>
+> If you know a package is stable, go ahead and install the JuliaHub
+> version. Otherwise, it's good to check how different the archived
+> version is from the current state. Click through the link under
+> "Repository" on the JuliaHub package page.
 
 ## Using and importing packages
 
@@ -120,6 +142,8 @@ import Trebuchet as Trebuchets
 ~~~
 {: .language-julia}
 
+[ghtreb]: https://github.com/FluxML/Trebuchet.jl
+[jhtreb]: https://juliahub.com/ui/Packages/Trebuchet
 [trebuchet]: https://juliahub.com/ui/Search?q=trebuchet&type=packages
 
 {% include links.md %}

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -51,7 +51,7 @@ In this environment she adds the `Trebuchet` package from its
 open source code [repository on GitHub][ghtreb] by typing
 
 ~~~
-(trebuchet) pkg> add https://github.com/FluxML/Trebuchet.jl
+(trebuchet) pkg> add Trebuchet#master
 ~~~
 {: .language-julia}
 

--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -102,7 +102,7 @@ environment.
 > ~~~
 > (trebuchet) pkg> add Trebuchet
 > ~~~
-> {: .language-julia)
+> {: .language-julia}
 >
 > However, that "release" version of the code is missing some
 > important features and, more important for learning, it has very
@@ -114,6 +114,7 @@ environment.
 > version. Otherwise, it's good to check how different the archived
 > version is from the current state. Click through the link under
 > "Repository" on the JuliaHub package page.
+{: .callout}
 
 ## Using and importing packages
 

--- a/_episodes/05-functions.md
+++ b/_episodes/05-functions.md
@@ -292,7 +292,8 @@ function is defined.
 > Macro names begin with `@` and they don't need parentheses or commas to
 > delimit their arguments.
 > Macros can transform any valid Julia expression and are quite powerful.
-> They can be expanded by first calling `@macroexpand`.
+> They can be expanded by prepending `@macroexpand` to the macro call of
+> interest.
 {: .callout}
 
 ~~~

--- a/_episodes/05-functions.md
+++ b/_episodes/05-functions.md
@@ -23,11 +23,14 @@ what she can do with it.
 
 Julia's `Base` module offers a handy function for inspecting other modules
 called `names`.
-Let's look at its docstring:
+Let's look at its docstring; remember that pressing <kbd>?</kbd>
+opens the __help?>__ prompt:
 
 ~~~
 help?> names
-
+~~~
+{: .language-julia}
+~~~
     names(x::Module; all::Bool = false, imported::Bool = false)
 
     Get an array of the names exported by a Module, excluding deprecated names.
@@ -38,29 +41,37 @@ help?> names
     As a special case, all names defined in Main are considered "exported", 
     since it is not idiomatic to explicitly export names from Main.
 ~~~
-{: .language-julia}
+{: .output}
+
+In Julia we have two types of arguments: _positional_ and _keyword_, separated
+by a semi-colon.
+
+1. _Positional arguments_ are determined by their position and thus the order
+   in which arguments are given to the function matters.
+2. _Keyword arguments_ are passed as a combination of the keyword and the
+   value to the function. They can be given in any order, but they need to
+   have a default value.
 
 > ## Positional and keyword arguments
 >
-> Let's take a closer look at the signature of the `names` function.
-> In Julia we have two types of arguments:
+> Let's take a closer look at the signature of the `names` function:
+> 
+> ~~~
+> names(x::Module; all::Bool = false, imported::Bool = false)
+> ~~~
+> {: .language-julia}
 >
-> 1. _Positional arguments_ are determined by their position and thus the order
->    in which arguments are given to the function matters. The `names` function
->    has one positional argument `x` of type `Module`.
-> 2. _Keyword arguments_ are passed as a combination of the keyword and the
->    value to the function. They can be given in any order, but they need to
->    have a default value. The `names` function has two keyword arguments
->    (`all` and `imported`) which are both of type `Bool` and default to
->    `false`.
+> It takes three arguments:
 >
-> Positional and keyword arguments are separated by a semi-colon.
-{: .callout}
-
-> ## Calling with keyword arguments
+> 1. `x`, a positional argument of type `Module`,  
+>    followed by a __`;`__ <!-- note: trailing spaces are deliberate-->
+> 2. `all`, a keyword argument of type `Bool` with a default value of
+>    `false`
+> 3. `imported`, another `Bool` keyword argument that defaults
+>    to `false`
 >
-> Suppose Melissa wanted to get `all` names of the `Trebuchets` module, what
-> would the call look like?
+> Suppose Melissa wanted to get all names of the `Trebuchets` module, including
+> those that are not exported. What would the function call look like?
 >
 > 1. `names(Trebuchets, true)`
 > 2. `names(Trebuchets, all = true)`
@@ -70,14 +81,25 @@ help?> names
 >
 > > ## Solution
 > >
-> > Option 5 is correct.
+> > 1. Both arguments are present, but `true` is presented without a keyword.
+> >    This throws a `MethodError: no method matching names(::Module, ::Bool)`
+> > 2. This is a __correct__ call.
+> > 3. This is also __correct__: you _can_ specify where the positional arguments
+> >    end with the `;`, but you do not have to.
+> > 4. Two arguments are present, but the keyword `all` is not assigned a
+>      value. This throws a
+> >    `MethodError: no method matching names(::Module, ::typeof(all))`
+> > 5. This is the __most correct__ answer.
 > {: .solution}
 {: .challenge}
 
-Thus Melissa executes
+Melissa goes ahead and executes
 
 ~~~
-julia> names(Trebuchets)
+names(Trebuchets)
+~~~
+{: .language-julia}
+~~~
 6-element Vector{Symbol}:
  :Trebuchet
  :TrebuchetState
@@ -86,25 +108,27 @@ julia> names(Trebuchets)
  :simulate
  :visualise
 ~~~
-{: .language-julia}
+{: .output}
 
 which yields the exported names of the `Trebuchets` module.
-By convention types are named with *CamelCase* while functions typically have
+By convention types are named with _CamelCase_ while functions typically have
 *snake_case*.
 Since Melissa is interested in simulating shots, she looks at the
-`Trebuchets.shoot` function
+`shoot` function from `Trebuchets` (again, using <kbd>?</kbd>):
 
 ~~~
 help?> Trebuchets.shoot
-
+~~~
+{: .language-julia}
+~~~
   shoot(ws, angle, w)
   shoot((ws, angle, w))
 
-  Shoots a Trebuchet with weight w. Releases the weight at the release angle 
-  angle in radians. The current wind speed is ws. Returns (t, dist), with 
-  travel time t and traveled distance dist.
+  Shoots a Trebuchet with weight w in kg. Releases the weight at the release
+  angle angle in radians. The current wind speed is ws in m/s. 
+  Returns (t, dist), with travel time t in s and travelled distance dist in m.
 ~~~
-{: .language-julia}
+{: .output}
 
 > ## Methods
 >
@@ -116,7 +140,10 @@ help?> Trebuchets.shoot
 Now she is ready to fire the first shot.
 
 ~~~
-julia> Trebuchets.shoot(5, 0.25pi, 500)
+Trebuchets.shoot(5, 0.25pi, 500)
+~~~
+{: .language-julia}
+~~~
 (TrebuchetState(Trebuchet.Lengths{Float64}(1.52, 2.07, 0.533, 0.607, 2.08, 0.831, 0.0379),
                 Trebuchet.Masses{Float64}(226.0, 0.149, 4.83),
                 Trebuchet.Angles{Float64}(-0.503, 1.32, 1.46),
@@ -134,17 +161,20 @@ julia> Trebuchets.shoot(5, 0.25pi, 500)
  117.8
 )
 ~~~
-{: .language-julia}
+{: .output}
 
 That is a lot of output, but Melissa is actually only interested in the
 distance, which is the second element of the tuple that was returned.
 So she tries again and grabs the second element this time:
 
 ~~~
-julia> Trebuchets.shoot(5, 0.25pi, 500)[2]
-117.8
+Trebuchets.shoot(5, 0.25pi, 500)[2]
 ~~~
 {: .language-julia}
+~~~
+117.8
+~~~
+{: .output}
 
 which means the shot traveled approximately 118 m.
 
@@ -155,9 +185,9 @@ take the second element.
 That's why she puts it together in a _function_ like this:
 
 ~~~
-julia> function shoot_distance(windspeed, angle, weight)
-           Trebuchets.shoot(windspeed, angle, weight)[2]
-       end
+function shoot_distance(windspeed, angle, weight)
+    Trebuchets.shoot(windspeed, angle, weight)[2]
+end
 ~~~
 {: .language-julia}
 
@@ -169,15 +199,26 @@ julia> function shoot_distance(windspeed, angle, weight)
 > same.
 {: .callout}
 
-### Adding methods
-
-Since Melissa wants to work with the structs `Trebuchet` and `Environment` she
-adds another convenience method for those
+Now Melissa can just call her wrapper function:
 
 ~~~
-julia> function shoot_distance(trebuchet::Trebuchet, env::Environment)
-           shoot_distance(env.wind, trebuchet.release_angle, trebuchet.counterweight)
-       end
+shoot_distance(5, 0.25pi, 500)
+~~~
+{: .language-julia}
+~~~
+117.8
+~~~
+{: .output}
+
+### Adding methods
+
+Since Melissa wants to work with the structs `Trebuchet` and `Environment`, she
+adds another convenience method for those:
+
+~~~
+function shoot_distance(trebuchet::Trebuchet, env::Environment)
+    shoot_distance(env.wind, trebuchet.release_angle, trebuchet.counterweight)
+end
 ~~~
 {: .language-julia}
 
@@ -192,12 +233,11 @@ Instead she can _slurp_ the arguments in the function definition and _splat_
 them in the function body using three dots (`...`) like this:
 
 ~~~
-julia> function shoot_distance(args...) # slurping
-           Trebuchets.shoot(args...)[2] # splatting
-       end
+function shoot_distance(args...) # slurping
+    Trebuchets.shoot(args...)[2] # splatting
+end
 ~~~
 {: .language-julia}
-
 
 ### Anonymous functions
 
@@ -207,16 +247,16 @@ These are _anonymous functions_.
 They can be defined with either the so-called stabby lambda notation,
 
 ~~~
-julia> (windspeed, angle, weight) -> Trebuchets.shoot(windspeed, angle, weight)[2]
+(windspeed, angle, weight) -> Trebuchets.shoot(windspeed, angle, weight)[2]
 ~~~
 {: .language-julia}
 
 or in long form, by omitting the name:
 
 ~~~
-julia> function (windspeed, angle, weight)
-           Trebuchets.shoot(windspeed, angle, weight)[2]
-       end
+function (windspeed, angle, weight)
+    Trebuchets.shoot(windspeed, angle, weight)[2]
+end
 ~~~
 {: .language-julia}
 
@@ -226,15 +266,18 @@ Melissa would like to set the fields of a `Trebuchet` using an index.
 She writes
 
 ~~~
-julia> trebuchet[1] = 2
+trebuchet[1] = 2
+~~~
+{: .language-julia}
+~~~
 ERROR: MethodError: no method matching setindex!(::Trebuchet, ::Int64, ::Int64)
 Stacktrace:
  [1] top-level scope
    @ REPL[4]:1
 ~~~
-{: .language-julia}
+{: .error}
 
-which tells her two things:
+The error tells her two things:
 
 1. a function named `setindex!` was called
 2. it didn't have a method for `Trebuchet`
@@ -244,19 +287,22 @@ where it is defined.
 There is a handy _macro_ named `@which` that obtains the module where the
 function is defined.
 
-~~~
-julia> @which setindex!
-Base
-~~~
-{: .language-julia}
-
 > ## Macros
 >
 > Macro names begin with `@` and they don't need parentheses or commas to
 > delimit their arguments.
 > Macros can transform any valid Julia expression and are quite powerful.
-> They can be expanded using `@macroexpand`.
+> They can be expanded by first calling `@macroexpand`.
 {: .callout}
+
+~~~
+@which setindex!
+~~~
+{: .language-julia}
+~~~
+Base
+~~~
+{: .output}
 
 Now Melissa knows she needs to add a method to `Base.setindex!` with the
 signature `(::Trebuchet, ::Int64, ::Int64)`.

--- a/_episodes/06-control-flow.md
+++ b/_episodes/06-control-flow.md
@@ -131,7 +131,7 @@ in which she needs to change the parameters to make the largest difference.
 > > ## Solution
 > >
 > > The correct solution is 4:
-> > `]` to enter pkg mode, then
+> > <kbd>]</kbd> to enter pkg mode, then
 > >
 > > ~~~
 > > pkg> add ForwardDiff

--- a/_episodes/06-control-flow.md
+++ b/_episodes/06-control-flow.md
@@ -239,6 +239,7 @@ Great! That didn't shoot past the target, but instead it landed a bit too short.
 > >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])
 > >   107.80646596787481
 > >   ~~~
+> >   {: .language-julia}
 > > * ~~~
 > >   better_trebuchet = imprecise_trebuchet - 0.02 * grad
 > >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])

--- a/_episodes/06-control-flow.md
+++ b/_episodes/06-control-flow.md
@@ -130,11 +130,13 @@ trebuchet[1] = 2
 ~~~
 {: .output}
 ~~~
-print(trebuchet)
+trebuchet
 ~~~
 {: .language-julia}
 ~~~
-[2.0, 0.7853981633974483]
+2-element Trebuchet:
+   2.0
+   0.7853981633974483
 ~~~
 {: .output}
 

--- a/_episodes/06-control-flow.md
+++ b/_episodes/06-control-flow.md
@@ -45,17 +45,42 @@ end
 language: `AbstractArray`s.
 An interface is a collection of methods that are all implemented by a certain
 type.
-For example, the [Julia
-manual](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array)
-lists all methods that a subtype of `AbstractArray` need to implement to adhere
-to the `AbstractArray` interface.
-If Melissa does this then her `Trebuchet` type will work with every function in
-`Base` that accepts an `AbstractArray`.
+For example, the [Julia manual][manual] lists all methods that a subtype of
+`AbstractArray` need to implement to adhere to the `AbstractArray` interface:
+
+- `size(A)` returns a tuple containing the dimensions of `A`
+- `getindex(A, i::Int)` returns the value associated with index `i`
+- `setindex!(A, v, i::Int)` writes a new value `v` at the index `i`
+
+If Melissa implements this interface for the `Trebuchet` type, it will work
+with every function in `Base` that accepts an `AbstractArray`.
 
 She also needs to make `Trebuchet` a proper subtype of `AbstractArray` as she
 tried in [the types episode]({{ site.baseurl }}{%link _episodes/03-types.md
 %}).
-Therefore she restarts her REPL.
+Therefore she _restarts her REPL_ and redefines `Trebuchet` and `Environment`,
+as well as the slurp-and-splat `shoot_distance` function:
+
+~~~
+import Trebuchet as Trebuchets
+
+mutable struct Trebuchet <: AbstractVector{Float64}
+  counterweight::Float64
+  release_angle::Float64
+end
+
+struct Environment
+    wind::Float64
+    target_distance::Float64
+end
+
+function shoot_distance(args...)
+    Trebuchets.shoot(args...)[2]
+end
+~~~
+{: .language-julia}
+
+Then she goes about implementing the `AbstractArray` interface.
 
 > ## Implement the `AbstractArray` interface for `Trebuchet`
 >
@@ -83,6 +108,23 @@ Therefore she restarts her REPL.
 > {: .solution}
 {: .challenge}
 
+With the new `Trebuchet` defined with a complete `AbstractArray` interface,
+Melissa tries again to modify a counterweight by index:
+
+~~~
+trebuchet = Trebuchet(500, 0.25pi)
+trebuchet[1] = 2
+print(trebuchet)
+~~~
+{: .language-julia}
+~~~
+2-element Trebuchet:
+ 500.0
+   0.7853981633974483
+2
+[2.0, 0.7853981633974483]
+~~~
+{: .output}
 
 ## Loops
 
@@ -105,7 +147,7 @@ But first Melissa needs a way to improve her parameters.
 > distance.
 >
 > The [_gradient_][grad] of a function gives the direction in which the return
-> value will change by the largest amount.
+> value will change when each input value changes.
 >
 > Since the `shoot_distance` function has three input parameters, the gradient
 > of `shoot_distance` will return a 3-element `Array`:
@@ -145,17 +187,22 @@ julia> grad = gradient(x -> (shoot_distance(x, environment) - environment.target
 -->
 
 ~~~
-julia> using ForwardDiff: gradient
+using ForwardDiff: gradient
 
-julia> imprecise_trebuchet = Trebuchet(500.0, 0.25pi);
-julia> environment = Environment(5.0, 100.0);
+imprecise_trebuchet = Trebuchet(500.0, 0.25pi);
+environment = Environment(5.0, 100.0);
 
-julia> grad = gradient(x -> (shoot_distance([environment.wind, x[2], x[1]] - environment.target_distance), imprecise_trebuchet)
-2-element Vector{Float64}:
- -47.1917378801788
-  -0.022101014146311698
+grad = gradient(x -> (shoot_distance([environment.wind, x[2], x[1]])
+                      - environment.target_distance),
+                imprecise_trebuchet)
 ~~~
 {: .language-julia}
+~~~
+2-element Vector{Float64}:
+  -0.02210101414630771
+ -47.191737880211264
+~~~
+{: .output}
 
 Melissa now changes her arguments a little bit in the direction of the gradient
 and checks the new distance.
@@ -165,17 +212,49 @@ and checks the new distance.
 ~~~
 julia> better_trebuchet = imprecise_trebuchet - 0.05 * grad;
 
-julia> shoot_distance([5, new_arguments...])
+julia> shoot_distance([5, better_trebuchet[2], better_trebuchet[1]])
 58.871526223121755
 ~~~
 {: .language-julia}
 
-That got shorter, but also a bit too short.
+Great! That didn't shoot past the target, but instead it landed a bit too short.
 
 > ## Experiment
 >
 > How far can you change the parameters in the direction of the gradient, such
 > that it still improves the distance?
+>
+> > ## Evaluation
+> >
+> > Try a bunch of values!
+> >
+> > * ~~~
+> >   better_trebuchet = imprecise_trebuchet - 0.04 * grad
+> >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])
+> >   120.48753521261001
+> >   ~~~
+> >   {: .language-julia}
+> > * ~~~
+> >   better_trebuchet = imprecise_trebuchet - 0.03 * grad
+> >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])
+> >   107.80646596787481
+> >   ~~~
+> > * ~~~
+> >   better_trebuchet = imprecise_trebuchet - 0.02 * grad
+> >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])
+> >   33.90699307740854
+> >   ~~~
+> >   {: .language-julia}
+> > * ~~~
+> >   better_trebuchet = imprecise_trebuchet - 0.025 * grad
+> >   shoot_distance([environment.wind, better_trebuchet[2], better_trebuchet[1]])
+> >   75.87613276409223
+> >   ~~~
+> >   {: .language-julia}
+> >
+> > Looks like the "best" trebuchet for a target 100 m away will be between
+> > 2.5% and 3% down the gradient from the imprecise trebuchet.
+> {: .solution}
 {: .discussion}
 
 ### For loops
@@ -186,22 +265,27 @@ She writes a new function `aim`, that performs the application of the gradient
 `N` times.
 
 ~~~
-julia> function aim(trebuchet, environment; N = 10, η = 0.05)
+function aim(trebuchet, environment; N = 10, η = 0.05)
            better_trebuchet = copy(trebuchet)
            for _ in 1:N
-               grad = gradient(x -> (shoot_distance([environment.wind, x[2], x[1]]) - environment.target_distance), better_trebuchet)
+               grad = gradient(x -> (shoot_distance([environment.wind, x[2], x[1]]) 
+                                     - environment.target_distance),
+                               better_trebuchet)
                better_trebuchet -= η * grad
                # short form of `better_trebuchet = better_trebuchet - η * grad`
            end
            return Trebuchet(better_trebuchet[1], better_trebuchet[2])
        end
 
-julia> better_trebuchet  = aim(imprecise_trebuchet, environment);
+better_trebuchet  = aim(imprecise_trebuchet, environment);
 
-julia> shoot_distance(better_trebuchet, environment)
-92.90796744088856
+shoot_distance(environment.wind, better_trebuchet[2], better_trebuchet[1])
 ~~~
 {: .language-julia}
+~~~
+90.14788588648652
+~~~
+{: .output}
 
 > ## Explore
 >
@@ -230,10 +314,13 @@ That's why she decides to change it a bit.
 This time she uses a `while`-loop to run the iterations until she is
 sufficiently near her target.
 
+(_Hint:_ __ε__ is `\epsilon`<kbd>tab</kbd>, and __η__ is `\eta`<kbd>tab</kbd>.)
+
 ~~~
-julia> function aim(trebuchet::Trebuchet, environment::Environment; ε = 1e-1, η = 0.05)
-            better_trebuchet = copy(trebuchet)
-            hit = x -> (shoot_distance([environment.wind, x[2], x[1]]) - environment.target_distance)
+function aim(trebuchet::Trebuchet, environment::Environment; ε = 0.1, η = 0.05)
+    better_trebuchet = copy(trebuchet)
+    hit = x -> (shoot_distance([environment.wind, x[2], x[1]])
+                - environment.target_distance)
             while abs(hit(better_trebuchet)) > ε
                 grad = gradient(hit, better_trebuchet)
                 better_trebuchet -= η * grad
@@ -241,19 +328,21 @@ julia> function aim(trebuchet::Trebuchet, environment::Environment; ε = 1e-1, �
             return Trebuchet(better_trebuchet[1], better_trebuchet[2])
         end
 
-julia> better_trebuchet = aim(imprecise_trebuchet, environment)
-2-element Trebuchet:
- 499.9498970976752
- 119.59293257732767
+better_trebuchet = aim(imprecise_trebuchet, environment);
 
-julia> shoot_distance(better_trebuchet, environment)
-100.0975848073789
+shoot_distance(better_trebuchet, environment)
 ~~~
 {: .language-julia}
+~~~
+100.0975848073789
+~~~
+{: .output}
 
-That is more what she had in mind.
+That is more what she had in mind. Your trebuchet may be tuned differently,
+but it should hit just as close as hers.
 
 [autodiff]: https://en.wikipedia.org/wiki/Automatic_differentiation
 [grad]: https://en.wikipedia.org/wiki/Gradient
+[manual]: https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array
 
 {% include links.md %}

--- a/_episodes/06-control-flow.md
+++ b/_episodes/06-control-flow.md
@@ -113,15 +113,27 @@ Melissa tries again to modify a counterweight by index:
 
 ~~~
 trebuchet = Trebuchet(500, 0.25pi)
-trebuchet[1] = 2
-print(trebuchet)
 ~~~
 {: .language-julia}
 ~~~
 2-element Trebuchet:
  500.0
    0.7853981633974483
+~~~
+{: .output}
+~~~
+trebuchet[1] = 2
+~~~
+{: .language-julia}
+~~~
 2
+~~~
+{: .output}
+~~~
+print(trebuchet)
+~~~
+{: .language-julia}
+~~~
 [2.0, 0.7853981633974483]
 ~~~
 {: .output}

--- a/_episodes/07-modules.md
+++ b/_episodes/07-modules.md
@@ -32,9 +32,13 @@ mutable struct Trebuchet <: AbstractVector{Float64}
   counterweight::Float64
   release_angle::Float64
 end
+
 Base.copy(trebuchet::Trebuchet) = Trebuchet(trebuchet.counterweight, trebuchet.release_angle)
+
 Base.size(trebuchet::Trebuchet) = tuple(2)
+
 Base.getindex(trebuchet::Trebuchet, i::Int) = getfield(trebuchet, i)
+
 function Base.setindex!(trebuchet::Trebuchet, v, i::Int)
     if i === 1
         trebuchet.counterweight = v
@@ -53,9 +57,11 @@ end
 function shoot_distance(windspeed, angle, weight)
     Trebuchets.shoot(windspeed, angle, weight)[2]
 end
+
 function shoot_distance(args...)
     Trebuchets.shoot(args...)[2]
 end
+
 function shoot_distance(trebuchet::Trebuchet, env::Environment)
     shoot_distance(env.wind, trebuchet.release_angle, trebuchet.counterweight)
 end
@@ -71,8 +77,11 @@ function aim(trebuchet::Trebuchet, environment::Environment; ε = 1e-1, η = 0.0
 end
 
 imprecise_trebuchet = Trebuchet(500.0, 0.25pi)
+
 environment = Environment(5, 100)
+
 precise_trebuchet = aim(imprecise_trebuchet, environment)
+
 shoot_distance(precise_trebuchet, environment)
 ~~~
 {: .language-julia title="aim_trebuchet.jl"}
@@ -109,9 +118,13 @@ mutable struct Trebuchet <: AbstractVecor{Float64}
   counterweight::Float64
   release_angle::Float64
 end
+
 Base.copy(trebuchet::Trebuchet) = Trebuchet(trebuchet.counterweight, trebuchet.release_angle)
+
 Base.size(trebuchet::Trebuchet) = tuple(2)
+
 Base.getindex(trebuchet::Trebuchet, i::Int) = getfield(trebuchet, i)
+
 function Base.setindex!(trebuchet::Trebuchet, v, i::Int)
     if i === 1
         trebuchet.counterweight = v
@@ -130,9 +143,11 @@ end
 function shoot_distance(windspeed, angle, weight)
     Trebuchets.shoot(windspeed, angle, weight)[2]
 end
+
 function shoot_distance(args...)
     Trebuchets.shoot(args...)[2]
 end
+
 function shoot_distance(trebuchet::Trebuchet, env::Environment)
     shoot_distance(env.wind, trebuchet.release_angle, trebuchet.counterweight)
 end
@@ -183,14 +198,17 @@ Melissa needs to take two things into account:
 Thus she now runs
 
 ~~~
-julia> using Revise
+using Revise
 
-julia> includet("MelissasModule.jl")
+includet("MelissasModule.jl")
 
-julia> include("MelissasCode.jl")
-100.0975848073789
+include("MelissasCode.jl")
 ~~~
 {: .language-julia}
+~~~
+100.0975848073789
+~~~
+{: .output}
 
 and any change she makes in `MelissasModule.jl` will be visible in the next run
 of her code.

--- a/_episodes/08-packages.md
+++ b/_episodes/08-packages.md
@@ -68,8 +68,8 @@ instead of needing to `includet MelissasModule.jl`, and she can write
 
 In order for her friends to be able to get the package, Melissa registers the
 package in the _general registry_.
-This can be done either via [juliahub][jh] or by making a pull request on
-[GitHub][gh] which can also be automated by the [Julia registrator][jr].
+This can be done either via [JuliaHub][jh] or by making a pull request on
+[GitHub][gh] which can also be automated by the [Julia Registrator][jr].
 
 ## Creating a new package
 

--- a/_episodes/09-tests.md
+++ b/_episodes/09-tests.md
@@ -80,8 +80,8 @@ example.
 > >     imprecise_trebuchet = Trebuchet(500.0, 0.25pi)
 > >     environment = Environment(5, 100)
 > >     precise_trebuchet = aim(imprecise_trebuchet, environment)
-> >     @test 100 - 1e-1 <= shoot_distance(precise_trebuchet, environment) <= 100 + 1e-1
-> >     # default ε is 1e-1
+> >     @test 100 - 0.1 <= shoot_distance(precise_trebuchet, environment) <= 100 + 0.1
+> >     # default ε is 0.1
 > > end
 > > ~~~
 > > {: .language-julia}

--- a/_includes/install-editor.html
+++ b/_includes/install-editor.html
@@ -1,0 +1,73 @@
+<div id="editor">
+  <h3>Text Editor</h3>
+
+  <p>
+    When you're writing code, it's nice to have a text editor that is
+    optimized for writing code, with features like automatic
+    color-coding of key words.
+  </p>
+  <p>
+    The default text editor on macOS and Linux is usually set
+    to <strong>Vim</strong>, which is not famous for being intuitive. If you
+    accidentally find yourself stuck in it, hit the <kbd>Esc</kbd> key,
+    followed by <kbd>:</kbd>+<kbd>Q</kbd>+<kbd>!</kbd> (colon, lower-case 'q',
+    exclamation mark), then hitting <kbd>Return</kbd> to return to the shell.
+  </p>
+  <p>
+    We will use <strong>nano</strong>, a simpler editor that is more forgiving
+    to newcomers. It will be familiar to you from The Carpentries' lessons on
+    the Unix Shell and Git.
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active">
+        <a data-os="windows" href="#editor-windows"
+           aria-controls="Windows" role="tab"
+           data-toggle="tab">Windows</a>
+      </li>
+      <li role="presentation">
+        <a data-os="macos" href="#editor-macos" aria-controls="MacOS"
+           role="tab" data-toggle="tab">MacOS</a>
+      </li>
+      <li role="presentation">
+        <a data-os="linux" href="#editor-linux" aria-controls="Linux"
+           role="tab" data-toggle="tab">Linux</a>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <article role="tabpanel" class="tab-pane active" id="editor-windows">
+        <p>
+          nano is a basic editor and the default that instructors use
+          in the workshop. It is installed along with Git.
+        </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="editor-macos">
+        <p>
+          nano is a basic editor and the default that instructors use
+          in the workshop. See the Git
+          installation <a href="#editor-macos-video-tutorial">video
+          tutorial</a> for an example on how to open nano. It should
+          be pre-installed.
+        </p>
+        <h4 id="editor-macos-video-tutorial">Video Tutorial</h4>
+        <div class="yt-wrapper2">
+          <div class="yt-wrapper">
+            <iframe type="text/html" frameborder="0"
+                    allow="accelerometer; autoplay; encrypted-media;
+                    gyroscope; picture-in-picture"
+                    src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0"
+                    class="yt-frame" allowfullscreen></iframe>
+          </div>
+        </div>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="editor-linux">
+        <p>
+          nano is a basic editor and the default that instructors use
+          in the workshop. It should be pre-installed.
+        </p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/_includes/install-julia.html
+++ b/_includes/install-julia.html
@@ -1,0 +1,94 @@
+<div id="julia">
+  <h3>Julia</h3>
+
+  <p>
+    Julia is a scientific programming language. You can find the latest
+    version, along with installation instructions for your operating system,
+    on the <a href="https://julialang.org/downloads/">Julia download page</a>.
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active">
+        <a data-os="windows" href="#julia-windows" aria-controls="Windows"
+           role="tab" data-toggle="tab">Windows</a>
+      </li>
+      <li role="presentation">
+        <a data-os="macos" href="#julia-macos" aria-controls="MacOS" role="tab"
+           data-toggle="tab">MacOS</a>
+      </li>
+      <li role="presentation">
+        <a data-os="linux" href="#julia-linux" aria-controls="Linux" role="tab"
+           data-toggle="tab">Linux</a>
+      </li>
+    </ul>
+    <div class="tab-content">
+      <article role="tabpanel" class="tab-pane active" id="julia-windows">
+        <ul>
+          <ol>
+            <li>
+              Open a web browser (Firefox, Chrome, etc.) and visit
+              the <a href="https://julialang.org/downloads/">Julia download
+              page</a>.
+            </li>
+            <li>
+              Download the <strong>Current stable release</strong> for Windows
+              by clicking the <strong>64-bit (installer)</strong> link.
+            </li>
+            <li>
+              Run the installer once it finishes downloading.
+            </li>
+            <li>
+              Click on Next to accept the default directory (or after
+              specifying your preferred installation location).
+            </li>
+            <li>
+              On the <em>Select Additional Tasks</em> screen
+              under <em>Other</em>, <strong>check the box to Add Julia to
+              PATH</strong>.
+            </li>
+            <li>
+              Click Next.
+            </li>
+            <li>
+              Click on Finish.
+            </li>
+          </ol>
+        </ul>
+        <p>
+          We will run Julia through the Git-Bash interface. Once you have it installed:
+        </p>
+        <ul>
+          <ol>
+            <li>
+              Open the Start menu and click on the <strong>Git</strong> folder.
+            </li>
+            <li>
+              Click on <strong>Git Bash</strong>&mdash;<em>not Git Cmd!</em>
+            </li>
+            <li>
+              A warning message might pop up about a missing icon: click "I
+              see," and continue.
+            </li>
+            <li>
+              Once the terminal window loads, type <kbd>julia</kbd> and enjoy the
+              lesson!
+            </li>
+          </ol>
+        </ul>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="julia-macos">
+        <p>
+          Julia comes pre-installed on macOS.
+        </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="julia-linux">
+        <p>
+          Julia comes pre-packaged for Linux: install <kbd>julia</kbd> through
+          apt, yum, etc. Just make sure the version you have installed is Julia
+          v1.16 or newer!
+        </p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/_includes/install-shell.html
+++ b/_includes/install-shell.html
@@ -1,0 +1,198 @@
+<div id="shell">
+  <h3>The Bash Shell</h3>
+  <p>
+    Bash is a commonly-used shell that gives you the power to do
+    tasks more quickly.
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active">
+        <a data-os="windows" href="#shell-windows" aria-controls="Windows"
+           role="tab" data-toggle="tab">Windows</a>
+      </li>
+      <li role="presentation">
+        <a data-os="macos" href="#shell-macos" aria-controls="MacOS"
+           role="tab" data-toggle="tab">MacOS</a>
+      </li>
+      <li role="presentation">
+        <a data-os="linux" href="#shell-linux" aria-controls="Linux"
+           role="tab" data-toggle="tab">Linux</a>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <article role="tabpanel" class="tab-pane active" id="shell-windows">
+        <ol>
+          <li>
+            Download the Git for Windows
+            <a href="https://gitforwindows.org/">installer</a>.
+          </li>
+          <li>
+            Run the installer and follow the steps below:
+            <ol>
+              {% comment %} Git 2.29.1 Setup {% endcomment %}
+              <li>
+                Click on "Next" four times (two times if you've previously
+                installed Git). You don't need to change anything in the
+                Information, location, components, and start menu screens.
+              </li>
+              <li>
+                <strong>
+                  From the dropdown menu select "Use the Nano editor by
+                  default" (NOTE: you will need to scroll <emph>up</emph> to
+                  find it) and click on "Next".
+                </strong>
+              </li>
+              {% comment %} Adjusting the name of the initial branch in new repositories {% endcomment %}
+              <li>
+                On the page that says "Adjusting the name of the initial branch
+                in new repositories", ensure that "Let Git decide" is selected.
+                This will ensure the highest level of compatibility for our
+                lessons.
+                {% comment %}
+                This section also has "Override the default branch name for new
+                repositories" and has a text box set to "main". I'm not having
+                people switch to this just yet because our git lesson still
+                uses the old paradigm.
+                {% endcomment %}
+              </li>
+              {% comment %} Adjusting your PATH environment {% endcomment %}
+              <li>
+                Ensure that "Git from the command line and also from 3rd-party
+                software" is selected and click on "Next". (If you don't do
+                this Git Bash will not work properly, requiring you to remove
+                the Git Bash installation, re-run the installer and to select
+                the "Git from the command line and also from 3rd-party
+                software" option.)
+              </li>
+              {% comment %} Choosing the SSH executable {% endcomment %}
+              {% comment %} Choosing HTTPS transport backend {% endcomment %}
+              <li>
+                Ensure that "Use the native Windows Secure Channel Library" is
+                selected and click on "Next".
+              </li>
+              {% comment %}
+              This should mean that people stuck behind corporate firewalls
+              that do MITM attacks with their own root CA are still able to
+              access remote git repos.
+              {% endcomment %}
+              {% comment %} Configuring the line ending conversions {% endcomment %}
+              <li>
+                Ensure that "Checkout Windows-style, commit Unix-style line
+                endings" is selected and click on "Next".
+              </li>
+              {% comment %} Configuring the terminal emulator to use with Git Bash {% endcomment %}
+              <li>
+                <strong>
+                  Ensure that "Use Windows' default console window" is selected
+                  and click on "Next".
+                </strong>
+              </li>
+              {% comment %} Configuring extra options {% endcomment %}
+              <li>
+                Ensure that "Default (fast-forward or merge) is selected and
+                click "Next".
+              </li>
+              <li>
+                Ensure that "Git Credential Manager <strong>Core</strong>" is
+                selected and click on "Next".
+              </li>
+              <li>
+                Ensure that "Enable file system caching" is selected and click on "Next".
+              </li>
+              {% comment %} Configuring experimental options {% endcomment %}
+              <li>Click on "Install".</li>
+              {% comment %} Installing {% endcomment %}
+              {% comment %} Completing the Git Setup Wizard {% endcomment %}
+              {% comment %}
+              as of 2020-06-02, the Window will say "click Finish", but the
+              button is labelled as "Next"
+              {% endcomment %}
+              <li>Click on "Finish" or "Next".</li>
+            </ol>
+          </li>
+          <li>
+            If your "HOME" environment variable is not set (or you don't know
+            what this is):
+            <ol>
+              <li>
+                Open command prompt (click on the Start Menu then
+                type <code>cmd</code> and press <kbd>Enter</kbd>)
+              </li>
+              <li>
+                Type the following line into the command prompt window exactly
+                as shown:
+                <p><code>setx HOME "%USERPROFILE%"</code></p>
+              </li>
+              <li>
+                Press <kbd>Enter</kbd>, you should see <code>SUCCESS: Specified
+                value was saved.</code>
+              </li>
+              <li>
+                Quit command prompt by typing <code>exit</code> then
+                pressing <kbd>Enter</kbd>
+              </li>
+            </ol>
+          </li>
+        </ol>
+        <p>
+          This will provide you with both Git and Bash in the Git Bash program.
+        </p>
+        <h4>Video Tutorial</h4>
+        <div class="yt-wrapper2">
+          <div class="yt-wrapper">
+            <iframe type="text/html" frameborder="0" allow="accelerometer;
+                    autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    src="https://www.youtube-nocookie.com/embed/339AEqk9c-8?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0"
+                    class="yt-frame" allowfullscreen></iframe>
+          </div>
+        </div>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="shell-macos">
+        <p>
+          The default shell in some versions of macOS is Bash, and Bash is
+          available in all versions, so no need to install anything. You access
+          Bash from the Terminal (found in
+          <code>/Applications/Utilities</code>). See the Git
+          installation <a href="#shell-macos-video-tutorial">video tutorial</a>
+          for an example on how to open the Terminal. You may want to keep
+          Terminal in your dock for this workshop.
+        </p>
+        <p>
+            To see if your default shell is Bash type <code>echo $SHELL</code>
+            in Terminal and press the <kbd>Return</kbd> key. If the message
+            printed does not end with '/bash' then your default is something
+            else and you can run Bash by typing <code>bash</code>
+        </p>
+        <p>
+          If you want to change your default shell,
+          see <a href="https://support.apple.com/en-au/HT208050"
+          rel="noopener"> this Apple Support article</a> and follow the
+          instructions on "How to change your default shell".
+        </p>
+        <h4 id="shell-macos-video-tutorial">Video Tutorial</h4>
+        <div class="yt-wrapper2">
+          <div class="yt-wrapper">
+            <iframe type="text/html" frameborder="0" allow="accelerometer;
+                    autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    src="https://www.youtube-nocookie.com/embed/9LQhwETCdwY?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0"
+                    class="yt-frame" allowfullscreen></iframe>
+          </div>
+        </div>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="shell-linux">
+        <p>
+          The default shell is usually Bash and there is usually no need to
+          install anything.
+        </p>
+        <p>
+          To see if your default shell is Bash type <code>echo $SHELL</code> in
+          a terminal and press the <kbd>Enter</kbd> key. If the message printed
+          does not end with '/bash' then your default is something else and you
+          can run Bash by typing <code>bash</code>.
+        </p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/setup.md
+++ b/setup.md
@@ -2,9 +2,11 @@
 title: Setup
 ---
 
-- Download the latest stable release of Julia from [julialang.org](https://julialang.org/downloads/), make sure that your Julia version is 1.6 or higher.
-- On windows it is recommended to install Julia via the windows store.
-- If you haven't already, install a terminal editor, for example [nano](https://www.nano-editor.org/download.php).
-- For this lesson it is recommended to start Julia by running `julia` from a Bash shell
+This lesson requires a terminal emulator ("shell"), a text editor
+("nano"), and Julia. Please make sure that all three are installed.
+
+{% include install-shell.html %}
+{% include install-editor.html %}
+{% include install-julia.html %}
 
 {% include links.md %}


### PR DESCRIPTION
This PR provides a minor cosmetic "facelift," with minor clarifications in a few places, removal of most **julia>** prompts in favor of separate `julia` and `output` codeblocks, and with a more detailed Setup page modeled after The Carpentries' Workshop Template. The GitHub version of `Trebuchet.jl` is now added (#30), and a minor bug (missing `)` in the call to `gradient`) has been fixed, both identified by working through the lesson.