### PR TITLE
make deactivation of local environment more prominent

### DIFF
--- a/_episodes/04-pkg.md
+++ b/_episodes/04-pkg.md
@@ -96,7 +96,37 @@ environment.
 ~~~
 {: .output}
 
-Melissa can get back to the global environment using `activate` without any parameters.
+### `deactivate` does not exist, instead ...
+
+Melissa can get back to the global environment using `activate` without any parameters. This will deactivate the `projects/trebuchet` environment. 
+
+~~~
+(trebuchet) pkg> activate
+~~~
+{: .language-julia}
+
+~~~
+  Activating project at `~/.julia/environments/v1.8`
+~~~
+{: .output}
+
+Melissa can test that she is back into the global environment by trying to import the `Trebuchets` package. She expects that this will fail, because the package is not available globally. It was only installed in the local environment `projects/trebuchet`.
+
+~~~
+julia> import Trebuchet as Trebuchets
+~~~
+{: .language-julia}
+
+~~~
+ │ Package Trebuchet not found, but a package named Trebuchet is available from a registry. 
+ │ Install package?
+ │   (@v1.9) pkg> add Trebuchet 
+ └ (y/n/o) [y]: n
+ERROR: ArgumentError: Package Trebuchet not found in current path.
+- Run `import Pkg; Pkg.add("Trebuchet")` to install the Trebuchet package.
+~~~
+{: .output}
+
 
 > ## Why use GitHub?
 >


### PR DESCRIPTION
Leaving a local environment is very important. Beginners may be irritated why all of a sudden installed packages are not present anymore. 
Also, people like myself coming from a different language where the `deactivate` command exists to leave a local (virtual) environment, may be lost as julia does NOT have a similar command.