### PR TITLE
Add exercises about help mode and shell mode

### DIFF
--- a/02_Getting_started.jl
+++ b/02_Getting_started.jl
@@ -160,6 +160,20 @@ distance_x_2 = 2 * distance
 # Great! This way she can easily look up the names she needs.
 #md # She gets back to normal mode by pressing <kbd>backspace</kbd>.
 
+# !!! challenge "Exploring Julia's Help Mode"
+#      Help mode can also be used to look up the documentation for Julia functions.
+#      Use Julia's help mode to read the documentation for the `varinfo()` function.
+#
+#     !!! solution
+#md #      If you are not already in help mode, type `?` to enter it. Then write `varinfo` and press enter.
+#md #
+#md #         ```julia-repl
+#md #         ?varinfo
+#md #         ```
+#nb #         ```julia
+#nb #         ?varinfo
+#nb #         ```
+
 # Another useful mode is the *shell mode* that can be
 #md # entered by pressing <kbd>;</kbd>. The prompt has now changed:
 #nb # used by prefacing a shell command with a <kbd>;</kbd>.
@@ -174,7 +188,46 @@ distance_x_2 = 2 * distance
 # confuse it with an actual shell: special shell syntax like piping won't work.
 #md # Like before, hit <kbd>backspace</kbd> to get back to the Julia prompt.
 
-# !!! challenge "Hello, `shell>` !"
+# !!! challenge "Hello, `shell>` (`pwd` and `cd`) !"
+#md #      Two commonly used shell commands are `pwd` (**p**rint **w**orking **d**irectory) and `cd` (**c**hange **d**irectory).
+#md #      1. Use `pwd` to find out what is your current working directory.
+#md #      2. Type the command `cd` in shell mode, which by default will bring you to your "home directory".
+#md #      3. Use `pwd` again. Did you get a different result from before? Why or why not?
+#     !!! solution
+#md #         ```julia-repl
+#md #         shell> pwd
+#md #         ```
+#md #
+#md #         ```julia-repl
+#md #         shell> cd
+#md #         ```
+#md #
+#md #         ```julia-repl
+#md #         shell> pwd
+#md #         ```
+#md #
+#md #      The working directory is the location from which you launched Julia.
+#md #      To navigate to a different directory, you can use the `cd` command by entering: `cd <directory>`. By default, this command will return you to your home directory if a specific directory is not given.
+#md #      If you initially launched Julia from your home directory, the working directory remains unchanged, so the output of the second `pwd` command will be identical to the first.
+#md #      Conversely, if you were in a different directory when you started Julia, the results of the two `pwd` commands will differ.
+#md #      You can use `cd -` to go back to your previous location.
+
+# !!! challenge "Hello, `shell>` (`ls`)!"
+#md #      Another useful shell command is `ls` (*list files*).
+#md #      Use it to show the contents of your home directory.
+#     !!! solution
+#md #         ```julia-repl
+#md #         shell> cd
+#md #         ```
+#md #
+#md #         ```julia-repl
+#md #         shell> ls
+#md #         ```
+#md #
+#md #      The first `cd` command will bring you to your home directory.
+#md #      `ls` will print a list of the files and directorys in your current location.
+
+# !!! challenge "Hello, `shell>` (`nano` and `cat`)!"
 #md #      Use the shell mode to create a file called `hello.jl` with the nano terminal text editor.
 #md #      Inside that file write the simple hello world program `print("Hello World!")`.
 #md #


### PR DESCRIPTION
Add exercises for the REPL lesson:
* One exercise for help mode about reading the documentation of the `varinfo()` function
* Two new exercises for shell mode, one about `pwd` and `cd`, the other about `ls`