### PR TITLE
Add example showing how to access struct fields

### DIFF
--- a/03_Julia_type_system.jl
+++ b/03_Julia_type_system.jl
@@ -133,6 +133,12 @@ environment = Environment(5, 100)
 # `trebuchet` is being called an _instance_ or _object_ of the type `Trebuchet`.
 # There can only ever be one definition of the type `Trebuchet` but you can create many instances of that type with different values for its fields.
 
+# Once an object has been created, you can access the values stored in its
+# fields using a dot (`.`) followed by the field name.
+# This lets us inspect the data stored in a particular instance.
+
+trebuchet.counterweight
+trebuchet.release_angle
 
 # ## Creating a subtype
 

--- a/08_Using_Modules.jl
+++ b/08_Using_Modules.jl
@@ -77,10 +77,6 @@ end
 
 imprecise_trebuchet = Trebuchet(500.0, 0.25pi)
 
-# accessing the fields
-imprecise_trebuchet.counterweight
-imprecise_trebuchet.release_angle
-
 environment = Environment(5, 100)
 
 precise_trebuchet = aim(imprecise_trebuchet, environment)

--- a/08_Using_Modules.jl
+++ b/08_Using_Modules.jl
@@ -77,6 +77,10 @@ end
 
 imprecise_trebuchet = Trebuchet(500.0, 0.25pi)
 
+# accessing the fields
+imprecise_trebuchet.counterweight
+imprecise_trebuchet.release_angle
+
 environment = Environment(5, 100)
 
 precise_trebuchet = aim(imprecise_trebuchet, environment)


### PR DESCRIPTION
This PR adds a short example showing how to access fields of a Julia object after it is created, using the Trebuchet example. Closes #121.